### PR TITLE
Configurable assessment behaviour: proctoring / answer review / feedback release

### DIFF
--- a/oral-assessment-instructor/src/components/CreateAssessmentForm.tsx
+++ b/oral-assessment-instructor/src/components/CreateAssessmentForm.tsx
@@ -4,6 +4,17 @@ import { apiService } from '../services/api';
 import { useAssessmentStore } from '../store/assessmentStore';
 import type { CreateAssessmentRequest } from '../../../shared/types/assessment';
 
+type AssessmentType = 'proctored-exam' | 'formative-practice' | 'custom';
+
+// Presets only set the three behaviour flags; answerMode is chosen independently.
+const PRESETS: Record<
+  Exclude<AssessmentType, 'custom'>,
+  Pick<CreateAssessmentRequest, 'proctored' | 'allowReview' | 'feedbackRelease'>
+> = {
+  'proctored-exam': { proctored: true, allowReview: false, feedbackRelease: 'manual' },
+  'formative-practice': { proctored: false, allowReview: true, feedbackRelease: 'immediate' },
+};
+
 export default function CreateAssessmentForm() {
   const navigate = useNavigate();
   const { addAssessment, setSelectedAssessment, setLoading, setError } = useAssessmentStore();
@@ -20,11 +31,30 @@ export default function CreateAssessmentForm() {
     scheduledWindowEnd: undefined,
     answerMode: 'oral',
     preparationTime: 60,
+    // Behaviour flags — default to the "Proctored exam" preset, i.e. today's behaviour.
+    proctored: true,
+    allowReview: false,
+    feedbackRelease: 'manual',
   });
 
   const [errors, setErrors] = useState<Partial<Record<keyof CreateAssessmentRequest | string, string>>>({});
+  const [assessmentType, setAssessmentType] = useState<AssessmentType>('proctored-exam');
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const initialFormData = useRef(formData);
   const hasSubmitted = useRef(false);
+
+  const applyPreset = (type: AssessmentType) => {
+    setAssessmentType(type);
+    if (type !== 'custom') {
+      setFormData((prev) => ({ ...prev, ...PRESETS[type] }));
+    }
+  };
+
+  // Editing an individual flag means the config no longer matches a named preset.
+  const setFlag = (patch: Partial<CreateAssessmentRequest>) => {
+    setFormData((prev) => ({ ...prev, ...patch }));
+    setAssessmentType('custom');
+  };
 
   // Warn on unsaved changes
   useEffect(() => {
@@ -382,6 +412,117 @@ export default function CreateAssessmentForm() {
         />
         <p className="mt-1 text-sm text-gray-500">Optional: 1-30 minutes per question. Leave blank for no time limit.</p>
         {errors.timeLimit && <p className="mt-1 text-sm text-red-400">{errors.timeLimit}</p>}
+      </div>
+
+      {/* Assessment Type (presets) */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Assessment Type
+        </label>
+        <div className="flex flex-col gap-2">
+          <label className="flex items-start space-x-2 cursor-pointer">
+            <input
+              type="radio"
+              name="assessmentType"
+              checked={assessmentType === 'proctored-exam'}
+              onChange={() => applyPreset('proctored-exam')}
+              className="mt-1 text-primary-600 focus:ring-primary-500"
+            />
+            <span className="text-sm">
+              <span className="font-medium text-gray-700">Proctored exam</span>
+              <span className="block text-gray-500">Webcam proctoring on, answers locked once submitted, results released manually.</span>
+            </span>
+          </label>
+          <label className="flex items-start space-x-2 cursor-pointer">
+            <input
+              type="radio"
+              name="assessmentType"
+              checked={assessmentType === 'formative-practice'}
+              onChange={() => applyPreset('formative-practice')}
+              className="mt-1 text-primary-600 focus:ring-primary-500"
+            />
+            <span className="text-sm">
+              <span className="font-medium text-gray-700">Formative practice</span>
+              <span className="block text-gray-500">No camera, students can revise their answers, feedback shown immediately.</span>
+            </span>
+          </label>
+          <label className="flex items-start space-x-2 cursor-pointer">
+            <input
+              type="radio"
+              name="assessmentType"
+              checked={assessmentType === 'custom'}
+              onChange={() => setAssessmentType('custom')}
+              className="mt-1 text-primary-600 focus:ring-primary-500"
+            />
+            <span className="text-sm">
+              <span className="font-medium text-gray-700">Custom</span>
+              <span className="block text-gray-500">Configure proctoring, review and feedback individually.</span>
+            </span>
+          </label>
+        </div>
+      </div>
+
+      {/* Advanced settings — per-flag override */}
+      <div>
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((s) => !s)}
+          className="text-sm font-medium text-primary-700 hover:text-primary-800"
+        >
+          {showAdvanced || assessmentType === 'custom' ? '▾' : '▸'} Advanced settings
+        </button>
+        {(showAdvanced || assessmentType === 'custom') && (
+          <div className="mt-3 bg-gray-100 rounded-lg p-4 space-y-4">
+            {/* Proctoring */}
+            <div>
+              <span className="block text-sm font-medium text-gray-700 mb-1">Webcam proctoring</span>
+              <div className="flex space-x-4">
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="proctored" checked={formData.proctored === true} onChange={() => setFlag({ proctored: true })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">On</span>
+                </label>
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="proctored" checked={formData.proctored === false} onChange={() => setFlag({ proctored: false })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">Off</span>
+                </label>
+              </div>
+            </div>
+            {/* Answer review */}
+            <div>
+              <span className="block text-sm font-medium text-gray-700 mb-1">Answer review</span>
+              <div className="flex space-x-4">
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="allowReview" checked={formData.allowReview === false} onChange={() => setFlag({ allowReview: false })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">Locked (one-shot, in order)</span>
+                </label>
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="allowReview" checked={formData.allowReview === true} onChange={() => setFlag({ allowReview: true })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">Allow revisiting &amp; editing</span>
+                </label>
+              </div>
+              <p className="mt-1 text-xs text-gray-500">Applies to written assessments.</p>
+            </div>
+            {/* Feedback release */}
+            <div>
+              <span className="block text-sm font-medium text-gray-700 mb-1">Feedback release</span>
+              <div className="flex space-x-4">
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="feedbackRelease" checked={formData.feedbackRelease === 'manual'} onChange={() => setFlag({ feedbackRelease: 'manual' })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">Manual (you release results)</span>
+                </label>
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="feedbackRelease" checked={formData.feedbackRelease === 'immediate'} onChange={() => setFlag({ feedbackRelease: 'immediate' })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">Immediate (as soon as graded)</span>
+                </label>
+              </div>
+            </div>
+            {formData.allowReview && formData.timeLimit != null && (
+              <p className="text-xs text-amber-600">
+                Heads up: per-question time limits and answer revisiting don't combine well — with review on, the timer is shown but won't auto-submit.
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Buttons */}

--- a/oral-assessment-student/src/components/ProgressTracker.tsx
+++ b/oral-assessment-student/src/components/ProgressTracker.tsx
@@ -14,6 +14,9 @@ interface ProgressTrackerProps {
   // with a distinct neutral marker — NOT the green check used for real answers.
   // Optional: when omitted, the tracker behaves exactly as before.
   skippedQuestionIds?: Set<string>;
+  // When provided (review mode), each indicator becomes a button that navigates to
+  // that question. When omitted the tracker is display-only, exactly as before.
+  onNavigate?: (index: number) => void;
 }
 
 export default function ProgressTracker({
@@ -23,6 +26,7 @@ export default function ProgressTracker({
   questionIds,
   answeredQuestionIds,
   skippedQuestionIds,
+  onNavigate,
 }: ProgressTrackerProps) {
   const percentage = calculatePercentage(answeredCount, totalQuestions);
 
@@ -67,10 +71,7 @@ export default function ProgressTracker({
             ? 'answered'
             : 'unanswered';
 
-          return (
-            <div
-              key={i}
-              className={`
+          const indicatorClass = `
                 w-8 h-8 rounded-lg font-medium text-xs flex items-center justify-center
                 ${isCurrent
                   ? 'bg-primary-600 text-white ring-2 ring-primary-300'
@@ -80,26 +81,46 @@ export default function ProgressTracker({
                   ? 'bg-green-100 text-green-800'
                   : 'bg-gray-100 text-gray-400'
                 }
-              `}
+                ${onNavigate ? 'cursor-pointer hover:ring-2 hover:ring-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-500' : ''}
+              `;
+
+          const indicatorContent = !isCurrent && isSkipped ? (
+            /* Skipped — neutral dash, deliberately NOT the answered check */
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 20 20" stroke="currentColor">
+              <path strokeLinecap="round" strokeWidth={2} d="M5 10h10" />
+            </svg>
+          ) : !isCurrent && isAnswered ? (
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          ) : (
+            i + 1
+          );
+
+          // Navigable (review mode) → button; otherwise display-only div (unchanged).
+          return onNavigate ? (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onNavigate(i)}
+              className={indicatorClass}
+              aria-label={`Go to question ${i + 1}, ${state}`}
+              aria-current={isCurrent ? 'step' : undefined}
+            >
+              {indicatorContent}
+            </button>
+          ) : (
+            <div
+              key={i}
+              className={indicatorClass}
               aria-label={`Question ${i + 1}, ${state}`}
               aria-current={isCurrent ? 'step' : undefined}
             >
-              {!isCurrent && isSkipped ? (
-                /* Skipped — neutral dash, deliberately NOT the answered check */
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 20 20" stroke="currentColor">
-                  <path strokeLinecap="round" strokeWidth={2} d="M5 10h10" />
-                </svg>
-              ) : !isCurrent && isAnswered ? (
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                  <path
-                    fillRule="evenodd"
-                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              ) : (
-                i + 1
-              )}
+              {indicatorContent}
             </div>
           );
         })}

--- a/oral-assessment-student/src/pages/InviteLanding.tsx
+++ b/oral-assessment-student/src/pages/InviteLanding.tsx
@@ -87,7 +87,7 @@ export default function InviteLanding() {
         <svg className="mx-auto h-12 w-12 text-indigo-500 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
-        <h2 className="text-lg font-semibold text-gray-900 mb-2">Oral Assessment Invitation</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-2">Assessment Invitation</h2>
         <p className="text-sm text-gray-600 mb-6">
           Click below to begin your assessment. This link can only be used once.
         </p>

--- a/oral-assessment-student/src/pages/TakeAssessment.tsx
+++ b/oral-assessment-student/src/pages/TakeAssessment.tsx
@@ -72,6 +72,8 @@ export default function TakeAssessment() {
     error,
     answerMode,
     preparationTime,
+    proctored,
+    allowReview,
     textAnswer,
     isRecording,
     isPaused,
@@ -89,6 +91,7 @@ export default function TakeAssessment() {
     setStudentInfo,
     loadQuestions,
     loadProgress,
+    goToQuestion,
     submitCurrentAnswer,
     submitCurrentTextAnswer,
     skipCurrentQuestion,
@@ -202,6 +205,7 @@ export default function TakeAssessment() {
     // Read the persisted decline directly too: on a refresh the restore-decline
     // effect and this effect both fire on the same mount, so proctoringDeclined
     // React state may still be its initial `false` here. sessionStorage is settled.
+    if (!proctored) return; // un-proctored assessment → never arm the camera
     const declined = proctoringDeclined || hasDeclinedConsent(assessmentId);
     if (!consentGiven || declined) return; // declined → run un-proctored, no block
 
@@ -234,6 +238,7 @@ export default function TakeAssessment() {
     questions.length,
     assessmentId,
     consentGiven,
+    proctored,
     proctoringDeclined,
     currentQuestionIndex,
     answeredQuestionIds.size,
@@ -685,6 +690,9 @@ export default function TakeAssessment() {
   const isLastQuestion = currentQuestionIndex === questions.length - 1;
   const answeredCount = progress?.answeredQuestions || 0;
   const currentAnswered = currentQuestion ? answeredQuestionIds.has(currentQuestion.id) : false;
+  // Review mode (written-only v1): free back-navigation + revise before final submit.
+  const reviewMode = answerMode === 'written' && allowReview;
+  const allAnswered = questions.length > 0 && answeredCount >= questions.length;
 
   // Derive a minimal assessment object for the overview screen.
   // The store's `assessment` field is only populated if the backend returns metadata;
@@ -702,8 +710,10 @@ export default function TakeAssessment() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
-      {/* Consent modal — only shown once questions have loaded successfully */}
-      {!consentGiven && questions.length > 0 && (
+      {/* Consent modal — only for proctored assessments, once questions have loaded.
+          Un-proctored assessments (e.g. written formative) skip it entirely; consentGiven
+          stays false so the camera resume logic never arms a stream. */}
+      {proctored && !consentGiven && questions.length > 0 && (
         <ConsentModal
           onConsent={handleConsentAccepted}
           onDecline={handleConsentDeclined}
@@ -711,8 +721,9 @@ export default function TakeAssessment() {
         />
       )}
 
-      {/* Pre-assessment overview — shown after consent, before question 1 */}
-      {consentGiven && !assessmentStarted && (
+      {/* Pre-assessment overview — shown after consent (or immediately when un-proctored),
+          before question 1 */}
+      {(consentGiven || !proctored) && !assessmentStarted && (
         <PreAssessmentOverview
           assessment={assessmentInfo}
           questionCount={questions.length}
@@ -775,14 +786,14 @@ export default function TakeAssessment() {
         />
       )}
 
-      {/* Proctoring PiP */}
-      <ProctorCamera stream={proctorStream} isRecording={isProctoringActive} />
+      {/* Proctoring PiP — only when this assessment is proctored */}
+      {proctored && <ProctorCamera stream={proctorStream} isRecording={isProctoringActive} />}
 
       {/* Header */}
       <header className="bg-white shadow-sm border-b flex-shrink-0">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <h1 className="text-2xl font-bold text-gray-900">
-            {assessment?.title ?? 'Oral Assessment'}
+            {assessment?.title ?? 'Assessment'}
           </h1>
           <div className="flex items-center justify-between mt-2">
             <div />
@@ -819,7 +830,9 @@ export default function TakeAssessment() {
                   serverStartedAtMs={
                     answerMode === 'written' ? parseServerStartedAtMs(currentQuestion.questionStartedAt) : undefined
                   }
-                  onExpire={handleTimerExpire}
+                  /* Review mode: the timer is a soft display only — never auto-submit,
+                     since answers can be revisited and revised. */
+                  onExpire={reviewMode ? undefined : handleTimerExpire}
                 />
               )}
             </div>
@@ -864,6 +877,7 @@ export default function TakeAssessment() {
               questionIds={questions.map((q) => q.id)}
               answeredQuestionIds={answeredQuestionIds}
               skippedQuestionIds={skippedQuestionIds}
+              onNavigate={reviewMode ? goToQuestion : undefined}
             />
           </div>
 
@@ -910,48 +924,90 @@ export default function TakeAssessment() {
             )}
           </div>
 
-          {/* Navigation — sequential only, no going back */}
-          <div className={`flex justify-end items-center ${isProctoringActive ? 'pb-32' : 'pb-6'}`}>
-            {isLastQuestion ? (
+          {/* Navigation */}
+          {reviewMode ? (
+            /* Review mode: free back-navigation + a persistent submit (enabled once
+               every question has an answer). Saving an answer never auto-advances. */
+            <div className="flex justify-between items-center pb-6">
               <button
-                onClick={() => setShowSubmitModal(true)}
-                disabled={!currentAnswered || isSubmittingAnswer}
-                className="flex items-center space-x-2 bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors font-medium"
+                type="button"
+                onClick={() => goToQuestion(currentQuestionIndex - 1)}
+                disabled={currentQuestionIndex === 0 || isUploading}
+                className="flex items-center space-x-2 bg-gray-100 text-gray-700 px-5 py-3 rounded-lg hover:bg-gray-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors font-medium"
               >
-                <span>Submit Assessment</span>
                 <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd"
-                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                    clipRule="evenodd" />
+                  <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
                 </svg>
+                <span>Previous</span>
               </button>
-            ) : (
-              <button
-                onClick={handleNext}
-                disabled={!currentAnswered || isSubmittingAnswer}
-                className="flex items-center space-x-2 bg-primary-600 text-white px-6 py-3 rounded-lg hover:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                {isSubmittingAnswer ? (
-                  <>
-                    <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <span>Loading next...</span>
-                  </>
-                ) : (
-                  <>
-                    <span>Next Question</span>
+              <div className="flex items-center space-x-3">
+                {!isLastQuestion && (
+                  <button
+                    type="button"
+                    onClick={() => goToQuestion(currentQuestionIndex + 1)}
+                    disabled={isUploading}
+                    className="flex items-center space-x-2 bg-primary-600 text-white px-5 py-3 rounded-lg hover:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <span>Next</span>
                     <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd"
-                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                        clipRule="evenodd" />
+                      <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
                     </svg>
-                  </>
+                  </button>
                 )}
-              </button>
-            )}
-          </div>
+                <button
+                  type="button"
+                  onClick={() => setShowSubmitModal(true)}
+                  disabled={!allAnswered || isUploading}
+                  title={!allAnswered ? 'Answer every question before submitting' : undefined}
+                  className="flex items-center space-x-2 bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors font-medium"
+                >
+                  <span>Submit Assessment</span>
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className={`flex justify-end items-center ${isProctoringActive ? 'pb-32' : 'pb-6'}`}>
+              {isLastQuestion ? (
+                <button
+                  onClick={() => setShowSubmitModal(true)}
+                  disabled={!currentAnswered || isSubmittingAnswer}
+                  className="flex items-center space-x-2 bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors font-medium"
+                >
+                  <span>Submit Assessment</span>
+                  <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd"
+                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                      clipRule="evenodd" />
+                  </svg>
+                </button>
+              ) : (
+                <button
+                  onClick={handleNext}
+                  disabled={!currentAnswered || isSubmittingAnswer}
+                  className="flex items-center space-x-2 bg-primary-600 text-white px-6 py-3 rounded-lg hover:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  {isSubmittingAnswer ? (
+                    <>
+                      <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                      </svg>
+                      <span>Loading next...</span>
+                    </>
+                  ) : (
+                    <>
+                      <span>Next Question</span>
+                      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd"
+                          d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                          clipRule="evenodd" />
+                      </svg>
+                    </>
+                  )}
+                </button>
+              )}
+            </div>
+          )}
         </div>
       </main>
 
@@ -969,12 +1025,16 @@ export default function TakeAssessment() {
             </p>
             {answeredCount < questions.length && (
               <p className="text-orange-600 text-sm mb-4">
-                Answers are submitted in order and are final. The {questions.length - answeredCount} unanswered question(s) can't be revisited.
+                {reviewMode
+                  ? `${questions.length - answeredCount} question(s) still need an answer before you can submit.`
+                  : `Answers are submitted in order and are final. The ${questions.length - answeredCount} unanswered question(s) can't be revisited.`}
               </p>
             )}
             {answeredCount >= questions.length && (
               <p className="text-gray-500 text-sm mb-6">
-                Answers are submitted in order and are final. Once submitted, your assessment will be sent for evaluation.
+                {reviewMode
+                  ? 'You can keep editing your answers until you submit. Once you submit, your assessment is final and sent for evaluation.'
+                  : 'Answers are submitted in order and are final. Once submitted, your assessment will be sent for evaluation.'}
               </p>
             )}
             {error && (

--- a/oral-assessment-student/src/services/api.ts
+++ b/oral-assessment-student/src/services/api.ts
@@ -200,6 +200,8 @@ export interface QuestionsResponse {
   currentQuestionIndex: number;
   answerMode: 'oral' | 'written';
   preparationTime?: number;
+  proctored?: boolean;
+  allowReview?: boolean;
   assessmentTitle?: string;
   assessmentCourse?: string;
   assessmentDescription?: string;
@@ -223,6 +225,8 @@ export async function getQuestions(
       currentQuestionIndex: response.data.currentQuestionIndex ?? 0,
       answerMode: response.data.answerMode || 'oral',
       preparationTime: response.data.preparationTime,
+      proctored: response.data.proctored,
+      allowReview: response.data.allowReview ?? false,
       assessmentTitle: response.data.assessmentTitle,
       assessmentCourse: response.data.assessmentCourse,
       assessmentDescription: response.data.assessmentDescription,

--- a/oral-assessment-student/src/store/assessmentStore.ts
+++ b/oral-assessment-student/src/store/assessmentStore.ts
@@ -76,6 +76,10 @@ interface AssessmentStore {
   // Answer mode — set by instructor, not student
   answerMode: 'oral' | 'written';
   preparationTime: number | null; // seconds of prep time for oral mode (null = no prep phase)
+  // Behaviour flags — set by instructor. proctored defaults true until questions load
+  // (the consent modal only renders once questions are present, so there is no flash).
+  proctored: boolean;
+  allowReview: boolean;
   textAnswer: string;
 
   // Proctoring state
@@ -211,6 +215,8 @@ export const useAssessmentStore = create<AssessmentStore>((set, get) => ({
   uploadProgress: 0,
   answerMode: 'oral' as 'oral' | 'written',
   preparationTime: null,
+  proctored: true,
+  allowReview: false,
   textAnswer: '',
   proctorStream: null,
   proctoring: null,
@@ -349,9 +355,12 @@ export const useAssessmentStore = create<AssessmentStore>((set, get) => ({
         currentQuestionIndex: result.currentQuestionIndex,
         answerMode: result.answerMode,
         preparationTime: result.preparationTime ?? null,
+        // proctored falls back to (answerMode === 'oral') if the backend omits it.
+        proctored: result.proctored ?? (result.answerMode === 'oral'),
+        allowReview: result.allowReview ?? false,
         assessment: {
           id: assessmentId!,
-          title: result.assessmentTitle || 'Oral Assessment',
+          title: result.assessmentTitle || 'Assessment',
           course: result.assessmentCourse || '',
           description: result.assessmentDescription || '',
           dueDate: '',
@@ -360,6 +369,8 @@ export const useAssessmentStore = create<AssessmentStore>((set, get) => ({
           status: 'open',
           answerMode: result.answerMode,
           preparationTime: result.preparationTime,
+          proctored: result.proctored ?? (result.answerMode === 'oral'),
+          allowReview: result.allowReview ?? false,
         },
         isLoading: false,
       });
@@ -700,8 +711,15 @@ export const useAssessmentStore = create<AssessmentStore>((set, get) => ({
     // No-op: going back is not allowed
   },
 
-  goToQuestion: () => {
-    // No-op: jumping is not allowed
+  goToQuestion: (index: number) => {
+    // Client-side jumping is only allowed in review mode (allowReview). In the strict
+    // flow this stays a no-op so sequential, server-driven navigation is unchanged.
+    const { allowReview, questions, currentQuestionIndex } = get();
+    if (!allowReview) return;
+    if (index < 0 || index >= questions.length || index === currentQuestionIndex) return;
+    const target = questions[index];
+    // Pre-fill the editor with the prior answer for the question we're landing on.
+    set({ currentQuestionIndex: index, textAnswer: target?.priorAnswer ?? '', error: null });
   },
 
   // ─── Submission ────────────────────────────────────────────────
@@ -785,10 +803,32 @@ export const useAssessmentStore = create<AssessmentStore>((set, get) => ({
     set({ isUploading: true, error: null });
 
     try {
-      await submitTextAnswer(studentId, currentQuestion.id, assessmentId, textAnswer.trim());
+      const submitted = textAnswer.trim();
+      await submitTextAnswer(studentId, currentQuestion.id, assessmentId, submitted);
 
       const newAnsweredIds = new Set(get().answeredQuestionIds);
       newAnsweredIds.add(currentQuestion.id);
+
+      if (get().allowReview) {
+        // Review mode: saving an answer must NOT advance or yank the student to the
+        // server frontier. Stay on the question, reflect the saved text locally (so
+        // navigating away and back pre-fills correctly), and clear any skip marker.
+        const newSkipped = new Set(get().skippedQuestionIds);
+        newSkipped.delete(currentQuestion.id);
+        const updatedQuestions = get().questions.map((q) =>
+          q.id === currentQuestion.id ? { ...q, priorAnswer: submitted } : q
+        );
+        set({
+          isUploading: false,
+          answeredQuestionIds: newAnsweredIds,
+          skippedQuestionIds: newSkipped,
+          questions: updatedQuestions,
+        });
+        clearTextDraft(assessmentId);
+        await get().loadProgress();
+        return;
+      }
+
       set({ isUploading: false, textAnswer: '', answeredQuestionIds: newAnsweredIds });
 
       // Submit confirmed — drop the durable text draft so it can't resurface on
@@ -988,6 +1028,8 @@ export const useAssessmentStore = create<AssessmentStore>((set, get) => ({
       uploadProgress: 0,
       answerMode: 'oral' as 'oral' | 'written',
       preparationTime: null,
+      proctored: true,
+      allowReview: false,
       textAnswer: '',
       proctorStream: null,
       proctoring: null,

--- a/oral-assessment-student/src/test/ProgressTracker.test.tsx
+++ b/oral-assessment-student/src/test/ProgressTracker.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import ProgressTracker from '../components/ProgressTracker';
 
 afterEach(cleanup);
@@ -73,5 +73,36 @@ describe('ProgressTracker', () => {
     expect(byLabel(container, 'Question 1, answered')!.className).toContain('bg-green-100');
     expect(byLabel(container, 'Question 2, answered')!.className).toContain('bg-green-100');
     expect(byLabel(container, 'Question 3, current')!.getAttribute('aria-current')).toBe('step');
+  });
+
+  it('is display-only (divs, not buttons) when onNavigate is omitted', () => {
+    const { container } = render(
+      <ProgressTracker currentIndex={0} totalQuestions={2} answeredCount={0} questionIds={['q1', 'q2']} />
+    );
+    // Indicators are plain divs and carry the display-only "Question N" label.
+    expect(byLabel(container, 'Question 1, current')!.tagName).toBe('DIV');
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('renders navigable buttons and fires onNavigate when provided (review mode)', () => {
+    const onNavigate = vi.fn();
+    const { container } = render(
+      <ProgressTracker
+        currentIndex={0}
+        totalQuestions={3}
+        answeredCount={1}
+        questionIds={['q1', 'q2', 'q3']}
+        answeredQuestionIds={new Set(['q2'])}
+        onNavigate={onNavigate}
+      />
+    );
+
+    // Navigable indicators are buttons with a "Go to question N" label.
+    const target = byLabel(container, 'Go to question 2, answered');
+    expect(target).not.toBeNull();
+    expect(target!.tagName).toBe('BUTTON');
+
+    fireEvent.click(target!);
+    expect(onNavigate).toHaveBeenCalledWith(1);
   });
 });

--- a/oral-assessment-student/src/test/assessmentStore.test.ts
+++ b/oral-assessment-student/src/test/assessmentStore.test.ts
@@ -167,3 +167,78 @@ describe('skipCurrentQuestion', () => {
     expect(api.submitTextAnswer).not.toHaveBeenCalled();
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// goToQuestion — client-side navigation, only in review mode (allowReview).
+// ────────────────────────────────────────────────────────────────────────────
+describe('goToQuestion', () => {
+  it('jumps to the index and pre-fills that question\'s prior answer when allowReview is true', () => {
+    useAssessmentStore.setState({
+      allowReview: true,
+      questions: [
+        { ...q('q1'), priorAnswer: 'answer one' },
+        { ...q('q2') },
+        { ...q('q3'), priorAnswer: 'answer three' },
+      ],
+      currentQuestionIndex: 0,
+      textAnswer: 'currently typing q1',
+    });
+
+    useAssessmentStore.getState().goToQuestion(2);
+    let s = useAssessmentStore.getState();
+    expect(s.currentQuestionIndex).toBe(2);
+    expect(s.textAnswer).toBe('answer three');
+
+    useAssessmentStore.getState().goToQuestion(1); // no prior answer → empty editor
+    s = useAssessmentStore.getState();
+    expect(s.currentQuestionIndex).toBe(1);
+    expect(s.textAnswer).toBe('');
+  });
+
+  it('is a no-op when allowReview is false (strict sequential flow unchanged)', () => {
+    useAssessmentStore.setState({
+      allowReview: false,
+      questions: [q('q1'), q('q2')],
+      currentQuestionIndex: 0,
+      textAnswer: 'keep me',
+    });
+
+    useAssessmentStore.getState().goToQuestion(1);
+    const s = useAssessmentStore.getState();
+    expect(s.currentQuestionIndex).toBe(0);
+    expect(s.textAnswer).toBe('keep me');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// submitCurrentTextAnswer — review mode saves without advancing or re-fetching.
+// ────────────────────────────────────────────────────────────────────────────
+describe('submitCurrentTextAnswer (review mode)', () => {
+  it('saves, reflects the answer locally, clears any skip, and does NOT advance or re-fetch questions', async () => {
+    useAssessmentStore.setState({
+      allowReview: true,
+      answerMode: 'written',
+      questions: [q('q1'), q('q2')],
+      currentQuestionIndex: 1,
+      textAnswer: 'my answer to q2',
+      answeredQuestionIds: new Set<string>(),
+      skippedQuestionIds: new Set<string>(['q2']),
+    });
+    vi.mocked(api.getProgress).mockResolvedValue({
+      ...baseProgress,
+      totalQuestions: 2,
+      answeredQuestions: 1,
+      answeredQuestionIds: ['q2'],
+    });
+
+    await useAssessmentStore.getState().submitCurrentTextAnswer();
+
+    const s = useAssessmentStore.getState();
+    expect(api.submitTextAnswer).toHaveBeenCalledWith('z1', 'q2', 'a1', 'my answer to q2');
+    expect(api.getQuestions).not.toHaveBeenCalled(); // no re-fetch / no index reset
+    expect(s.currentQuestionIndex).toBe(1); // stayed on the question
+    expect(s.answeredQuestionIds.has('q2')).toBe(true);
+    expect(s.skippedQuestionIds.has('q2')).toBe(false); // skip marker cleared
+    expect(s.questions[1].priorAnswer).toBe('my answer to q2'); // reflected locally for re-nav
+  });
+});

--- a/oral-assessment-student/src/types/index.ts
+++ b/oral-assessment-student/src/types/index.ts
@@ -25,6 +25,11 @@ export interface Question {
    * out of scope here — no endpoint is added or called.
    */
   questionStartedAt?: string;
+  /**
+   * The student's previously-submitted text answer for this question. Only populated
+   * in review (allowReview) mode so the UI can pre-fill it when navigating back.
+   */
+  priorAnswer?: string;
 }
 
 export interface Answer {
@@ -108,6 +113,10 @@ export interface Assessment {
   status: string;
   answerMode?: 'oral' | 'written';
   preparationTime?: number;
+  /** Webcam proctoring. Unset → treat as (answerMode === 'oral'). */
+  proctored?: boolean;
+  /** Student may navigate back and revise answers before final submit (written v1). */
+  allowReview?: boolean;
 }
 
 export interface UploadUrlResponse {

--- a/shared/types/assessment.ts
+++ b/shared/types/assessment.ts
@@ -128,6 +128,12 @@ export interface CreateAssessmentRequest {
   scheduledWindowEnd?: string;
   answerMode?: 'oral' | 'written';
   preparationTime?: number;
+  /** Webcam proctoring. Unset → backend defaults to (answerMode === 'oral'). */
+  proctored?: boolean;
+  /** Allow students to navigate back and revise answers before final submit (written v1). */
+  allowReview?: boolean;
+  /** 'immediate' shows results as soon as graded; 'manual' requires instructor release. */
+  feedbackRelease?: 'immediate' | 'manual';
 }
 
 export interface UploadStudentsRequest {

--- a/src/main/controllers/assessment_router.py
+++ b/src/main/controllers/assessment_router.py
@@ -112,6 +112,9 @@ async def create_assessment(
             rubric=request.rubric,
             answer_mode=request.answerMode,
             preparation_time=request.preparationTime,
+            proctored=request.proctored,
+            allow_review=request.allowReview,
+            feedback_release=request.feedbackRelease,
             max_score_per_question=request.maxScorePerQuestion,
             grade_cutoffs=request.gradeCutoffs,
         ))

--- a/src/main/controllers/student_router.py
+++ b/src/main/controllers/student_router.py
@@ -107,6 +107,7 @@ async def get_student_questions(
                 topic=q.get("topic"),
                 timeLimit=q.get("timeLimit"),
                 createdAt=q.get("createdAt", ""),
+                priorAnswer=q.get("priorAnswer"),
             )
             for q in raw_questions
         ]
@@ -119,6 +120,8 @@ async def get_student_questions(
             currentQuestionIndex=result.get("currentQuestionIndex", 0) if isinstance(result, dict) else 0,
             answerMode=result.get("answerMode", "oral") if isinstance(result, dict) else "oral",
             preparationTime=result.get("preparationTime") if isinstance(result, dict) else None,
+            proctored=result.get("proctored") if isinstance(result, dict) else None,
+            allowReview=result.get("allowReview", False) if isinstance(result, dict) else False,
             assessmentTitle=result.get("assessmentTitle") if isinstance(result, dict) else None,
             assessmentCourse=result.get("assessmentCourse") if isinstance(result, dict) else None,
             assessmentDescription=result.get("assessmentDescription") if isinstance(result, dict) else None,

--- a/src/main/dtos/InstructorAssessmentDTOs.py
+++ b/src/main/dtos/InstructorAssessmentDTOs.py
@@ -24,6 +24,9 @@ class CreateAssessmentRequest(BaseModel):
     rubric: Optional[str] = Field(None, description="Custom grading rubric injected into the evaluation prompt")
     answerMode: str = Field("oral", description="'oral' or 'written' — controls student answer interface")
     preparationTime: Optional[int] = Field(None, description="Seconds of prep time shown before oral recording starts (0 = start immediately)", ge=0, le=300)
+    proctored: Optional[bool] = Field(None, description="Webcam proctoring on/off. When unset, defaults to (answerMode == 'oral') for backward compatibility.")
+    allowReview: bool = Field(False, description="Allow students to navigate back and revise earlier answers before final submit (written mode in v1).")
+    feedbackRelease: str = Field("manual", description="'immediate' (results shown as soon as graded) or 'manual' (instructor must release).")
     maxScorePerQuestion: Optional[int] = Field(None, description="Override max marks per question (default 10)", ge=1, le=100)
     gradeCutoffs: Optional[Dict[str, float]] = Field(None, description="Override grade cutoffs as percentages, e.g. {'excellent': 90, 'competent': 75, 'developing': 60}")
 

--- a/src/main/dtos/StudentAssessmentDTOs.py
+++ b/src/main/dtos/StudentAssessmentDTOs.py
@@ -45,6 +45,9 @@ class QuestionResponse(BaseModel):
     topic: Optional[str] = None
     timeLimit: Optional[int] = None
     createdAt: str
+    # Student's prior answer text, only populated in review (allowReview) mode so the
+    # UI can pre-fill it when navigating back to an answered question.
+    priorAnswer: Optional[str] = None
 
 
 class StudentQuestionsResponse(BaseModel):
@@ -57,6 +60,8 @@ class StudentQuestionsResponse(BaseModel):
     currentQuestionIndex: int = 0
     answerMode: str = "oral"
     preparationTime: Optional[int] = None
+    proctored: Optional[bool] = None
+    allowReview: bool = False
     assessmentTitle: Optional[str] = None
     assessmentCourse: Optional[str] = None
     assessmentDescription: Optional[str] = None

--- a/src/main/service/InstructorAssessmentService.py
+++ b/src/main/service/InstructorAssessmentService.py
@@ -128,6 +128,9 @@ class InstructorAssessmentService:
         rubric: Optional[str] = None,
         answer_mode: str = "oral",
         preparation_time: Optional[int] = None,
+        proctored: Optional[bool] = None,
+        allow_review: bool = False,
+        feedback_release: str = "manual",
         max_score_per_question: Optional[int] = None,
         grade_cutoffs: Optional[Dict[str, float]] = None,
     ) -> Dict[str, Any]:
@@ -182,6 +185,12 @@ class InstructorAssessmentService:
                 'rubric': rubric,
                 'answerMode': answer_mode,
                 'preparationTime': preparation_time,
+                # Behaviour flags. proctored defaults to (answer_mode == 'oral') so
+                # existing oral assessments are unchanged; allowReview/feedbackRelease
+                # default to today's locked, manual-release behaviour.
+                'proctored': proctored if proctored is not None else (answer_mode == 'oral'),
+                'allowReview': bool(allow_review),
+                'feedbackRelease': feedback_release,
                 'status': 'draft',
                 'createdAt': created_at,
                 'updatedAt': created_at

--- a/src/main/service/OralAssessmentAnswerSubmission.py
+++ b/src/main/service/OralAssessmentAnswerSubmission.py
@@ -20,6 +20,7 @@ class OralAssessmentAnswerSubmission:
         duration: Optional[int] = None,
         text_content: Optional[str] = None,
         video_url: Optional[str] = None,
+        allow_review: bool = False,
     ) -> Dict[str, Any]:
         # Validate required fields per answer type
         if answer_type == "text" and not (text_content and text_content.strip()):
@@ -54,12 +55,17 @@ class OralAssessmentAnswerSubmission:
             dynamo_item["audioUrl"] = audio_url or ""
             dynamo_item["duration"] = duration or 0
 
-        # Conditional put to prevent duplicate submissions (atomic check-and-store)
         from boto3.dynamodb.conditions import Attr
-        self.table.put_item(
-            Item=dynamo_item,
-            ConditionExpression=Attr("SK").not_exists(),
-        )
+        if allow_review:
+            # Review mode: upsert so a student can revise an earlier answer. The set of
+            # ANSWER# items is unchanged by an overwrite, so progress counts stay correct.
+            self.table.put_item(Item=dynamo_item)
+        else:
+            # Conditional put to prevent duplicate submissions (atomic check-and-store)
+            self.table.put_item(
+                Item=dynamo_item,
+                ConditionExpression=Attr("SK").not_exists(),
+            )
 
         self.progress_updater(student_id, assessment_id)
 

--- a/src/main/service/OralAssessmentResultsAggregator.py
+++ b/src/main/service/OralAssessmentResultsAggregator.py
@@ -91,7 +91,9 @@ class OralAssessmentResultsAggregator:
             item["SK"].replace("EVALUATION#", ""): item for item in evaluations_response.get("Items", [])
         }
 
-        if not assessment.get("resultsReleased"):
+        # feedbackRelease == 'immediate' bypasses the manual instructor release gate
+        # (formative flows); 'manual' (default / legacy) still requires resultsReleased.
+        if assessment.get("feedbackRelease") != "immediate" and not assessment.get("resultsReleased"):
             raise ValueError(f"Results not released yet for student {student_id}")
 
         if not evaluations_map:

--- a/src/main/service/OralAssessmentService.py
+++ b/src/main/service/OralAssessmentService.py
@@ -180,14 +180,24 @@ class OralAssessmentService:
             raw_time_limit = int(assessment_meta.get("timeLimit", 0)) or None
             assessment_time_limit = raw_time_limit
 
+            # Behaviour flags surfaced to the student app. proctored falls back to
+            # (answerMode == 'oral') for legacy assessments created before this field.
+            answer_mode = assessment_meta.get("answerMode", "oral")
+            proctored = assessment_meta.get("proctored")
+            if proctored is None:
+                proctored = answer_mode == "oral"
+            allow_review = bool(assessment_meta.get("allowReview", False))
+
             student_items = self.question_access.get_student_questions(student_id, assessment_id)
             bank_items = self.question_access.get_bank_questions(assessment_id)
 
             if not student_items and not bank_items:
                 logger.warning(f"No questions found for assessment {assessment_id}")
                 return {"questions": [], "currentQuestionIndex": 0,
-                        "answerMode": assessment_meta.get("answerMode", "oral"),
+                        "answerMode": answer_mode,
                         "preparationTime": assessment_meta.get("preparationTime"),
+                        "proctored": proctored,
+                        "allowReview": allow_review,
                         "assessmentTitle": assessment_meta.get("title"),
                         "assessmentCourse": assessment_meta.get("course"),
                         "assessmentDescription": assessment_meta.get("description")}
@@ -235,15 +245,31 @@ class OralAssessmentService:
             else:
                 current_idx = int(enrollment.get("currentQuestionIdx", 0))
 
-            # Gate: only return full content for answered + current question
-            gated_questions = self.question_access.gate_question_content(all_questions, current_idx)
+            if allow_review:
+                # Review mode: every question is navigable, so return full content for all
+                # and attach the student's prior answer text so the UI can pre-fill it.
+                answers_resp = self.table.query(
+                    KeyConditionExpression=Key("PK").eq(f"STUDENT#{student_id}#ASSESSMENT#{assessment_id}")
+                        & Key("SK").begins_with("ANSWER#")
+                )
+                answers_by_qid = {a.get("questionId"): a for a in answers_resp.get("Items", [])}
+                for q in all_questions:
+                    prior = answers_by_qid.get(q.get("id"))
+                    if prior is not None:
+                        q["priorAnswer"] = prior.get("textContent")
+                gated_questions = all_questions
+            else:
+                # Gate: only return full content for answered + current question
+                gated_questions = self.question_access.gate_question_content(all_questions, current_idx)
 
             logger.info(f"Retrieved {len(gated_questions)} questions for student {student_id} (current={current_idx})")
             return {
                 "questions": self._convert_decimals(gated_questions),
                 "currentQuestionIndex": current_idx,
-                "answerMode": assessment_meta.get("answerMode", "oral"),
+                "answerMode": answer_mode,
                 "preparationTime": assessment_meta.get("preparationTime"),
+                "proctored": proctored,
+                "allowReview": allow_review,
                 "assessmentTitle": assessment_meta.get("title"),
                 "assessmentCourse": assessment_meta.get("course"),
                 "assessmentDescription": assessment_meta.get("description"),
@@ -257,8 +283,12 @@ class OralAssessmentService:
             logger.error(f"Failed to get questions: {e}")
             raise OralAssessmentServiceError(f"Database error: {e}")
     
-    def _validate_question_order(self, student_id: str, assessment_id: str, question_id: str) -> None:
-        """Check sequential ordering: reject duplicates and out-of-order. Does NOT advance the index."""
+    def _validate_question_order(self, student_id: str, assessment_id: str, question_id: str, allow_review: bool = False) -> None:
+        """Check question ordering. Does NOT advance the index.
+
+        Strict (default): reject duplicates and out-of-order submissions.
+        Review mode: allow any question that belongs to this student's frozen order, in
+        any order, and allow re-submission (revision) of an already-answered question."""
         enrollment_key = {"PK": f"ASSESSMENT#{assessment_id}", "SK": f"STUDENT#{student_id}"}
         enrollment = self.table.get_item(Key=enrollment_key).get("Item")
         if not enrollment:
@@ -266,6 +296,13 @@ class OralAssessmentService:
 
         question_order = enrollment.get("questionOrder", [])
         current_idx = int(enrollment.get("currentQuestionIdx", 0))
+
+        if allow_review:
+            # Only reject a question that isn't part of this student's order. Duplicates
+            # are legitimate revisions; order is free.
+            if question_id not in question_order:
+                raise OralAssessmentServiceError("Question submitted out of order")
+            return
 
         # Reject duplicate submission
         existing = self.table.get_item(
@@ -278,11 +315,22 @@ class OralAssessmentService:
         if current_idx >= len(question_order) or question_order[current_idx] != question_id:
             raise OralAssessmentServiceError("Question submitted out of order")
 
-    def _advance_question_index(self, student_id: str, assessment_id: str) -> None:
-        """Advance currentQuestionIdx after answer is successfully stored."""
+    def _advance_question_index(self, student_id: str, assessment_id: str, allow_review: bool = False, question_id: Optional[str] = None) -> None:
+        """Advance currentQuestionIdx after an answer is stored.
+
+        In review mode currentQuestionIdx is a monotonic "furthest reached" marker: only
+        advance when the answer was for the question currently at the frontier (a forward
+        step), never when revising an earlier question."""
         enrollment_key = {"PK": f"ASSESSMENT#{assessment_id}", "SK": f"STUDENT#{student_id}"}
         enrollment = self.table.get_item(Key=enrollment_key).get("Item", {})
         current_idx = int(enrollment.get("currentQuestionIdx", 0))
+
+        if allow_review:
+            question_order = enrollment.get("questionOrder", [])
+            at_frontier = current_idx < len(question_order) and question_order[current_idx] == question_id
+            if not at_frontier:
+                return  # revising an earlier question — leave the frontier where it is
+
         try:
             self.table.update_item(
                 Key=enrollment_key,
@@ -324,8 +372,11 @@ class OralAssessmentService:
             OralAssessmentServiceError: If assessment window is closed or DB error
         """
         try:
-            self._check_assessment_window(assessment_id)
-            self._validate_question_order(student_id, assessment_id, question_id)
+            # Single METADATA read, reused for the window check + the review flag.
+            meta = self._get_assessment_metadata(assessment_id)
+            allow_review = bool(meta.get("allowReview", False))
+            self._check_assessment_window(assessment_id, metadata=meta)
+            self._validate_question_order(student_id, assessment_id, question_id, allow_review=allow_review)
             result = self.answer_submission.submit_answer(
                 student_id=student_id,
                 question_id=question_id,
@@ -335,8 +386,9 @@ class OralAssessmentService:
                 duration=duration,
                 text_content=text_content,
                 video_url=video_url,
+                allow_review=allow_review,
             )
-            self._advance_question_index(student_id, assessment_id)
+            self._advance_question_index(student_id, assessment_id, allow_review=allow_review, question_id=question_id)
             logger.info(f"Recorded answer for question {question_id} from student {student_id}")
             return result
         except self.table.meta.client.exceptions.ConditionalCheckFailedException:

--- a/tests/service/test_oral_assessment_service.py
+++ b/tests/service/test_oral_assessment_service.py
@@ -147,6 +147,35 @@ class TestGetStudentQuestions:
         assert result["questions"] == []
         assert result["currentQuestionIndex"] == 0
 
+    def test_proctored_defaults_from_answer_mode_when_absent(self, dynamo_env):
+        """Legacy assessment (no proctored field, no answerMode) → proctored True (oral)."""
+        table = dynamo_env
+        _seed_assessment(table)  # no answerMode → 'oral', no proctored field
+        _seed_enrollment(table)
+        _seed_questions(table, count=2)
+        svc = _create_service(table)
+
+        result = svc.get_student_questions("s-1", "a-1")
+        assert result["proctored"] is True
+        assert result["allowReview"] is False
+
+    def test_written_assessment_defaults_unproctored(self, dynamo_env):
+        """answerMode='written' with no explicit proctored flag → proctored False."""
+        table = dynamo_env
+        _seed_assessment(table)
+        table.update_item(
+            Key={"PK": "ASSESSMENT#a-1", "SK": "METADATA"},
+            UpdateExpression="SET answerMode = :m",
+            ExpressionAttributeValues={":m": "written"},
+        )
+        _seed_enrollment(table)
+        _seed_questions(table, count=2)
+        svc = _create_service(table)
+
+        result = svc.get_student_questions("s-1", "a-1")
+        assert result["answerMode"] == "written"
+        assert result["proctored"] is False
+
 
 # ─────────────────────────────────────────────────────────────
 # submit_answer
@@ -268,6 +297,131 @@ class TestSubmitAnswer:
         assert "videoUrl" not in item
         assert "textContent" not in item
         assert "duration" not in item
+
+
+def _enable_review(table, assessment_id="a-1"):
+    """Flip allowReview=True on the assessment metadata."""
+    table.update_item(
+        Key={"PK": f"ASSESSMENT#{assessment_id}", "SK": "METADATA"},
+        UpdateExpression="SET allowReview = :r",
+        ExpressionAttributeValues={":r": True},
+    )
+
+
+def _current_idx(table, student_id="s-1", assessment_id="a-1") -> int:
+    item = table.get_item(Key={"PK": f"ASSESSMENT#{assessment_id}", "SK": f"STUDENT#{student_id}"})["Item"]
+    return int(item.get("currentQuestionIdx", 0))
+
+
+class TestReviewMode:
+    """allowReview=True: free navigation + revise. Strict path must stay byte-for-byte."""
+
+    def test_allows_out_of_order_submission(self, dynamo_env):
+        table = dynamo_env
+        _seed_assessment(table)
+        _enable_review(table)
+        _seed_enrollment(table)
+        _seed_questions(table, count=2)
+        _seed_question_order(table, question_ids=["q-1", "q-2"])
+        svc = _create_service(table)
+
+        # q-2 submitted before q-1 — allowed in review mode.
+        result = svc.submit_answer(
+            student_id="s-1", question_id="q-2", assessment_id="a-1",
+            answer_type="text", text_content="answer to two first",
+        )
+        assert result["ok"] is True
+
+    def test_rejects_question_not_in_order(self, dynamo_env):
+        table = dynamo_env
+        _seed_assessment(table)
+        _enable_review(table)
+        _seed_enrollment(table)
+        _seed_questions(table, count=2)
+        _seed_question_order(table, question_ids=["q-1", "q-2"])
+        svc = _create_service(table)
+
+        with pytest.raises(OralAssessmentServiceError, match="out of order"):
+            svc.submit_answer(
+                student_id="s-1", question_id="q-999", assessment_id="a-1",
+                answer_type="text", text_content="not a real question",
+            )
+
+    def test_allows_revision_upsert(self, dynamo_env):
+        table = dynamo_env
+        _seed_assessment(table)
+        _enable_review(table)
+        _seed_enrollment(table)
+        _seed_questions(table, count=1)
+        _seed_question_order(table, question_ids=["q-1"])
+        svc = _create_service(table)
+
+        svc.submit_answer(student_id="s-1", question_id="q-1", assessment_id="a-1",
+                          answer_type="text", text_content="first attempt")
+        # Re-submit the same question with revised text — allowed (overwrite).
+        svc.submit_answer(student_id="s-1", question_id="q-1", assessment_id="a-1",
+                          answer_type="text", text_content="revised attempt")
+
+        item = table.get_item(Key={"PK": "STUDENT#s-1#ASSESSMENT#a-1", "SK": "ANSWER#q-1"})["Item"]
+        assert item["textContent"] == "revised attempt"
+
+    def test_strict_mode_rejects_revision_when_flag_absent(self, dynamo_env):
+        """No allowReview field → today's behaviour: second submit raises 'already submitted'."""
+        table = dynamo_env
+        _seed_assessment(table)  # no allowReview
+        _seed_enrollment(table)
+        _seed_questions(table, count=1)
+        _seed_question_order(table, question_ids=["q-1"])
+        svc = _create_service(table)
+
+        svc.submit_answer(student_id="s-1", question_id="q-1", assessment_id="a-1",
+                          answer_type="text", text_content="first")
+        with pytest.raises(OralAssessmentServiceError, match="already submitted"):
+            svc.submit_answer(student_id="s-1", question_id="q-1", assessment_id="a-1",
+                              answer_type="text", text_content="second")
+
+    def test_frontier_only_index_advance(self, dynamo_env):
+        table = dynamo_env
+        _seed_assessment(table)
+        _enable_review(table)
+        _seed_enrollment(table)
+        _seed_questions(table, count=3)
+        _seed_question_order(table, question_ids=["q-1", "q-2", "q-3"])
+        svc = _create_service(table)
+
+        # Submit q-2 first (not the frontier) — index stays at 0.
+        svc.submit_answer(student_id="s-1", question_id="q-2", assessment_id="a-1",
+                          answer_type="text", text_content="two")
+        assert _current_idx(table) == 0
+        # Submit q-1 (the frontier) — index advances to 1.
+        svc.submit_answer(student_id="s-1", question_id="q-1", assessment_id="a-1",
+                          answer_type="text", text_content="one")
+        assert _current_idx(table) == 1
+        # Revise q-1 (no longer the frontier) — index unchanged.
+        svc.submit_answer(student_id="s-1", question_id="q-1", assessment_id="a-1",
+                          answer_type="text", text_content="one-revised")
+        assert _current_idx(table) == 1
+
+    def test_get_questions_ungates_and_attaches_prior_answer(self, dynamo_env):
+        table = dynamo_env
+        _seed_assessment(table)
+        _enable_review(table)
+        _seed_enrollment(table)
+        _seed_questions(table, count=3)
+        # A prior written answer to q-1.
+        table.put_item(Item={
+            "PK": "STUDENT#s-1#ASSESSMENT#a-1", "SK": "ANSWER#q-1",
+            "questionId": "q-1", "answerType": "text", "textContent": "my earlier answer",
+        })
+        svc = _create_service(table)
+
+        result = svc.get_student_questions("s-1", "a-1")
+        qs = {q["id"]: q for q in result["questions"]}
+        assert len(qs) == 3
+        # Un-gated: every question keeps its text (no stripping of "future" questions).
+        assert all(q.get("text") for q in qs.values())
+        assert qs["q-1"]["priorAnswer"] == "my earlier answer"
+        assert qs["q-2"].get("priorAnswer") is None
 
 
 # ─────────────────────────────────────────────────────────────
@@ -497,6 +651,32 @@ class TestGetStudentResults:
 
         with pytest.raises(OralAssessmentServiceError, match="not released"):
             svc.get_student_results("s-1", "a-1")
+
+    def test_immediate_feedback_release_bypasses_gate(self, dynamo_env):
+        """feedbackRelease='immediate' returns results even when resultsReleased is False."""
+        table = dynamo_env
+        _seed_assessment(table)  # resultsReleased = False
+        table.update_item(
+            Key={"PK": "ASSESSMENT#a-1", "SK": "METADATA"},
+            UpdateExpression="SET feedbackRelease = :f",
+            ExpressionAttributeValues={":f": "immediate"},
+        )
+        _seed_enrollment(table, status="submitted")
+
+        pk = "STUDENT#s-1#ASSESSMENT#a-1"
+        table.put_item(Item={"PK": pk, "SK": "QUESTION#q-1", "text": "Q1", "questionType": "general"})
+        table.put_item(Item={"PK": pk, "SK": "ANSWER#q-1", "audioUrl": "s3://b/a1.webm", "duration": 30})
+        table.put_item(Item={
+            "PK": pk, "SK": "EVALUATION#q-1",
+            "totalScore": 5, "maxScore": 10,
+            "correctnessScore": 3, "understandingScore": 2,
+            "feedback": "ok", "strengths": [], "weaknesses": [], "suggestedImprovements": [],
+        })
+        svc = _create_service(table)
+
+        results = svc.get_student_results("s-1", "a-1")
+        assert results["totalScore"] == 5
+        assert len(results["questions"]) == 1
 
     def test_unenrolled_student_raises(self, dynamo_env):
         table = dynamo_env


### PR DESCRIPTION
## What & why

The student app was built as a proctored oral exam. To also run an **in-tutorial written formative diagnostic** (no camera, students revise, instant feedback) without bolting implicit special-cases onto `answerMode`, three behaviours become **explicit per-assessment settings**:

| Flag | Meaning | Default when absent (legacy-safe) |
|---|---|---|
| `proctored` | webcam consent + recording | `answerMode == 'oral'` |
| `allowReview` | free back-nav + revise before final submit | `false` |
| `feedbackRelease` | `immediate` vs `manual` (instructor release) | `manual` |

This also removes a latent limitation — proctoring was previously *derived* from `answerMode`, so a proctored written exam or unproctored oral practice was impossible.

## Instructor UX
"Assessment Type" presets — **Formative practice** (off / on / immediate), **Proctored exam** (on / off / manual), **Custom** — with a collapsible Advanced section to override each flag.

## Backend
- Flags plumbed through the create DTO → metadata → student GET.
- `feedbackRelease == 'immediate'` skips the `resultsReleased` gate in the results aggregator (pairs with `auto_evaluate`, which still triggers grading).
- `allowReview` relaxes the in-order / no-overwrite invariant **only when set** (membership check, answer upsert, frontier-only index advance). Strict path is byte-for-byte unchanged when false.
- `get_student_questions` un-gates all questions and returns each question's prior `textContent` for pre-fill in review mode.

## Student app
- Consent modal + camera + revoke/regrant overlays gate on `proctored`; an un-proctored assessment skips the webcam screen entirely. Neutralised "Oral Assessment" copy.
- Review mode (written + `allowReview`): navigable progress tracker, Previous/Next, a persistent Submit (enabled once all answered), branched modal copy, soft (non-auto-submitting) timer.

## Scope / follow-ups
- `allowReview` is **written-only in v1** (oral review needs presigned-audio re-download + timer reconciliation).
- Flags are set at create time only (no edit path yet).
- `proctored` + written records video fine but won't silently re-arm the camera after a mid-exam refresh.

## Tests
- Backend: full suite green, +9 new (proctored default, immediate release, out-of-order / revise / frontier / un-gate; a test proving the strict path still rejects a second submit when the flag is absent).
- Student: green, +5 (goToQuestion gating, review-mode save, navigable tracker). `tsc -b` + lint clean.
- Instructor: type-check + lint clean.