### PR TITLE
fix(oral-eval): evaluate each student on submit + expose autoEvaluate in UI

### DIFF
--- a/oral-assessment-instructor/src/components/CreateAssessmentForm.tsx
+++ b/oral-assessment-instructor/src/components/CreateAssessmentForm.tsx
@@ -6,13 +6,15 @@ import type { CreateAssessmentRequest } from '../../../shared/types/assessment';
 
 type AssessmentType = 'proctored-exam' | 'formative-practice' | 'custom';
 
-// Presets only set the three behaviour flags; answerMode is chosen independently.
+// Presets only set the behaviour flags; answerMode is chosen independently.
 const PRESETS: Record<
   Exclude<AssessmentType, 'custom'>,
-  Pick<CreateAssessmentRequest, 'proctored' | 'allowReview' | 'feedbackRelease'>
+  Pick<CreateAssessmentRequest, 'proctored' | 'allowReview' | 'feedbackRelease' | 'autoEvaluate'>
 > = {
-  'proctored-exam': { proctored: true, allowReview: false, feedbackRelease: 'manual' },
-  'formative-practice': { proctored: false, allowReview: true, feedbackRelease: 'immediate' },
+  // Auto-evaluate on both: the exam scores automatically but you release results
+  // manually; formative scores and shows feedback immediately.
+  'proctored-exam': { proctored: true, allowReview: false, feedbackRelease: 'manual', autoEvaluate: true },
+  'formative-practice': { proctored: false, allowReview: true, feedbackRelease: 'immediate', autoEvaluate: true },
 };
 
 export default function CreateAssessmentForm() {
@@ -35,6 +37,7 @@ export default function CreateAssessmentForm() {
     proctored: true,
     allowReview: false,
     feedbackRelease: 'manual',
+    autoEvaluate: true,
   });
 
   const [errors, setErrors] = useState<Partial<Record<keyof CreateAssessmentRequest | string, string>>>({});
@@ -430,7 +433,7 @@ export default function CreateAssessmentForm() {
             />
             <span className="text-sm">
               <span className="font-medium text-gray-700">Proctored exam</span>
-              <span className="block text-gray-500">Webcam proctoring on, answers locked once submitted, results released manually.</span>
+              <span className="block text-gray-500">Webcam proctoring on, answers locked once submitted, auto-scored on submit, results released manually.</span>
             </span>
           </label>
           <label className="flex items-start space-x-2 cursor-pointer">
@@ -443,7 +446,7 @@ export default function CreateAssessmentForm() {
             />
             <span className="text-sm">
               <span className="font-medium text-gray-700">Formative practice</span>
-              <span className="block text-gray-500">No camera, students can revise their answers, feedback shown immediately.</span>
+              <span className="block text-gray-500">No camera, students can revise their answers, auto-scored with feedback shown immediately.</span>
             </span>
           </label>
           <label className="flex items-start space-x-2 cursor-pointer">
@@ -516,6 +519,26 @@ export default function CreateAssessmentForm() {
                 </label>
               </div>
             </div>
+            {/* Automatic AI evaluation */}
+            <div>
+              <span className="block text-sm font-medium text-gray-700 mb-1">Automatic AI evaluation</span>
+              <div className="flex space-x-4">
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="autoEvaluate" checked={formData.autoEvaluate === true} onChange={() => setFlag({ autoEvaluate: true })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">On (score each student as they submit)</span>
+                </label>
+                <label className="flex items-center space-x-2 cursor-pointer">
+                  <input type="radio" name="autoEvaluate" checked={formData.autoEvaluate === false} onChange={() => setFlag({ autoEvaluate: false })} className="text-primary-600 focus:ring-primary-500" />
+                  <span className="text-gray-700 text-sm">Off (evaluate manually later)</span>
+                </label>
+              </div>
+              <p className="mt-1 text-xs text-gray-500">When on, a student's answers are AI-evaluated as soon as they submit — no need to wait for the whole class or click Evaluate.</p>
+            </div>
+            {formData.feedbackRelease === 'immediate' && !formData.autoEvaluate && (
+              <p className="text-xs text-amber-600">
+                Heads up: "immediate" feedback release has no effect unless automatic AI evaluation is on — with auto-evaluation off, there's nothing to show until you evaluate manually.
+              </p>
+            )}
             {formData.allowReview && formData.timeLimit != null && (
               <p className="text-xs text-amber-600">
                 Heads up: per-question time limits and answer revisiting don't combine well — with review on, the timer is shown but won't auto-submit.

--- a/shared/types/assessment.ts
+++ b/shared/types/assessment.ts
@@ -134,6 +134,8 @@ export interface CreateAssessmentRequest {
   allowReview?: boolean;
   /** 'immediate' shows results as soon as graded; 'manual' requires instructor release. */
   feedbackRelease?: 'immediate' | 'manual';
+  /** Automatically evaluate each student's answers as soon as that student submits. */
+  autoEvaluate?: boolean;
 }
 
 export interface UploadStudentsRequest {

--- a/src/main/controllers/student_router.py
+++ b/src/main/controllers/student_router.py
@@ -189,41 +189,42 @@ async def submit_assessment(
             assessment_id=request.assessment_id,
         ))
 
-        # Auto-evaluate in background so the last student's response isn't delayed
-        def _maybe_auto_evaluate():
+        # Auto-evaluate THIS student's answers as soon as they submit. Evaluation
+        # is per-student, not gated on the whole roster finishing: an open or
+        # formative assessment may never reach 100% submission (only a subset of
+        # enrolled students ever participate), so a "wait for all" gate would mean
+        # feedback never fires. Runs in a background thread so the student's submit
+        # response isn't blocked on enqueueing.
+        def _auto_evaluate_student():
             try:
                 assessment = instructor_svc.get_assessment(request.assessment_id)
                 if not assessment.get("autoEvaluate"):
                     return
-                submitted, total = instructor_svc.count_submitted_students(request.assessment_id)
-                if total <= 0 or submitted < total:
-                    logger.info(
-                        "[AutoEval] Holding off for assessment %s — %d/%d students submitted",
-                        request.assessment_id, submitted, total,
-                    )
-                    return
-                all_students = instructor_svc.get_assessment_students(request.assessment_id)
                 job_manager = get_batch_job_manager()
                 job_id = job_manager.create_job(
                     job_type=JobType.EVALUATION,
                     assessment_id=request.assessment_id,
-                    total_items=len(all_students),
-                    metadata={"assessment_title": assessment.get("title", ""), "trigger": "auto"},
+                    total_items=1,
+                    metadata={
+                        "assessment_title": assessment.get("title", ""),
+                        "trigger": "auto_on_submit",
+                        "student_id": student_id,
+                    },
                 )
-                dispatcher.enqueue_evaluation_batch(
+                enqueued = dispatcher.enqueue_evaluation_batch(
                     job_id=job_id,
                     assessment_id=request.assessment_id,
-                    students=all_students,
+                    students=[{"studentId": student_id}],
                 )
                 logger.info(
-                    "[AutoEval] Triggered evaluation job %s for assessment %s (%d students)",
-                    job_id, request.assessment_id, len(all_students),
+                    "[AutoEval] Enqueued evaluation for student %s in assessment %s (job %s, %d message)",
+                    student_id, request.assessment_id, job_id, enqueued,
                 )
             except Exception as auto_err:
-                logger.error("[AutoEval] Failed to trigger auto-evaluation: %s", auto_err)
+                logger.error("[AutoEval] Failed to trigger per-student auto-evaluation: %s", auto_err)
 
         import threading
-        threading.Thread(target=_maybe_auto_evaluate, daemon=True).start()
+        threading.Thread(target=_auto_evaluate_student, daemon=True).start()
 
         return SubmitAssessmentResponse(**result)
 

--- a/src/main/dtos/InstructorAssessmentDTOs.py
+++ b/src/main/dtos/InstructorAssessmentDTOs.py
@@ -20,7 +20,7 @@ class CreateAssessmentRequest(BaseModel):
     accessMode: str = Field("open", description="'open' or 'scheduled'")
     scheduledWindowStart: Optional[str] = Field(None, description="ISO datetime for window start (scheduled mode)")
     scheduledWindowEnd: Optional[str] = Field(None, description="ISO datetime for window end (scheduled mode)")
-    autoEvaluate: bool = Field(False, description="Automatically trigger evaluation when all students submit")
+    autoEvaluate: bool = Field(False, description="Automatically evaluate each student's answers as soon as that student submits")
     rubric: Optional[str] = Field(None, description="Custom grading rubric injected into the evaluation prompt")
     answerMode: str = Field("oral", description="'oral' or 'written' — controls student answer interface")
     preparationTime: Optional[int] = Field(None, description="Seconds of prep time shown before oral recording starts (0 = start immediately)", ge=0, le=300)

--- a/src/main/service/InstructorAssessmentService.py
+++ b/src/main/service/InstructorAssessmentService.py
@@ -144,7 +144,7 @@ class InstructorAssessmentService:
             due_date: Due date (ISO format)
             total_questions: Number of questions to generate
             time_limit: Time limit per question in minutes (optional)
-            auto_evaluate: Trigger evaluation automatically when all students submit
+            auto_evaluate: Automatically evaluate each student's answers as soon as that student submits
             rubric: Custom grading rubric injected into the evaluation prompt
 
         Returns:

--- a/tests/controllers/test_sprint7.py
+++ b/tests/controllers/test_sprint7.py
@@ -297,30 +297,40 @@ class TestAutoEvalTrigger:
         assert resp.status_code == 200
         dispatcher.enqueue_evaluation_batch.assert_not_called()
 
-    def test_no_trigger_when_not_all_submitted(self):
+    def test_triggers_per_student_even_when_not_all_submitted(self):
+        # Per-student: a student's own submission triggers evaluation of THEIR
+        # answers immediately — it is NOT gated on the whole roster finishing.
+        # (An open/formative assessment may never reach 100% submission.)
         oral_svc = MagicMock()
         oral_svc.submit_assessment.return_value = self._submission_result()
         instructor_svc = _mock_instructor_svc(
             assessment={"id": "a-1", "title": "T", "createdBy": "i-1", "autoEvaluate": True, "rubric": None},
-            submitted_counts=(1, 2),  # only 1 of 2 submitted
+            submitted_counts=(1, 2),  # only 1 of 2 submitted — must still trigger
         )
         dispatcher = MagicMock()
-        client = _student_client(oral_svc=oral_svc, instructor_svc=instructor_svc, dispatcher=dispatcher)
-        resp = client.put("/api/student/s-1/submit", json={"assessment_id": "a-1"})
-        assert resp.status_code == 200
-        dispatcher.enqueue_evaluation_batch.assert_not_called()
+        dispatcher.enqueue_evaluation_batch.return_value = 1
 
-    def test_trigger_when_all_submitted_and_auto_evaluate_true(self):
+        with patch("src.main.controllers.student_router.get_batch_job_manager") as mock_jm:
+            mock_jm.return_value.create_job.return_value = "auto-job-partial"
+            client = _student_client(oral_svc=oral_svc, instructor_svc=instructor_svc, dispatcher=dispatcher)
+            resp = client.put("/api/student/s-1/submit", json={"assessment_id": "a-1"})
+
+        assert resp.status_code == 200
+        dispatcher.enqueue_evaluation_batch.assert_called_once_with(
+            job_id="auto-job-partial",
+            assessment_id="a-1",
+            students=[{"studentId": "s-1"}],
+        )
+
+    def test_triggers_for_submitting_student_when_auto_evaluate_true(self):
+        # Only the submitting student is enqueued, not the whole roster.
         oral_svc = MagicMock()
         oral_svc.submit_assessment.return_value = self._submission_result()
-        students = [{"studentId": "s-1"}, {"studentId": "s-2"}]
         instructor_svc = _mock_instructor_svc(
             assessment={"id": "a-1", "title": "T", "createdBy": "i-1", "autoEvaluate": True, "rubric": None},
-            students=students,
-            submitted_counts=(2, 2),  # all submitted
         )
         dispatcher = MagicMock()
-        dispatcher.enqueue_evaluation_batch.return_value = 2
+        dispatcher.enqueue_evaluation_batch.return_value = 1
 
         with patch("src.main.controllers.student_router.get_batch_job_manager") as mock_jm:
             mock_jm.return_value.create_job.return_value = "auto-job-1"
@@ -331,8 +341,13 @@ class TestAutoEvalTrigger:
         dispatcher.enqueue_evaluation_batch.assert_called_once_with(
             job_id="auto-job-1",
             assessment_id="a-1",
-            students=students,
+            students=[{"studentId": "s-1"}],
         )
+        # create_job records a single-item job tagged as an on-submit trigger.
+        _, jm_kwargs = mock_jm.return_value.create_job.call_args
+        assert jm_kwargs["total_items"] == 1
+        assert jm_kwargs["metadata"]["trigger"] == "auto_on_submit"
+        assert jm_kwargs["metadata"]["student_id"] == "s-1"
 
     def test_submission_succeeds_even_if_auto_eval_fails(self):
         oral_svc = MagicMock()


### PR DESCRIPTION
## Problem

Formative assessments were getting **no AI scores** despite presets promising immediate feedback. Root cause is three compounding gaps:

1. **UI gap** — the backend `autoEvaluate` flag was never wired into the instructor create form, so every UI-created assessment defaulted to `false`.
2. **Preset trap** — the `formative-practice` preset set `feedbackRelease: 'immediate'` (a *display* gate only) but did not enable evaluation, so there was nothing to display.
3. **Gate mismatch** — the auto-eval trigger only fired once **every enrolled student** had submitted. For an open/formative assessment where only a subset of the roster participates (e.g. 26 of 395), that condition never opens.

## Changes

**Backend**
- `submit` trigger now evaluates the **submitting student's** answers immediately (per-student), enqueuing a single-student evaluation job — no longer gated on the whole roster finishing.
- `autoEvaluate` field/docstring wording updated to match.

**Frontend (instructor)**
- Expose `autoEvaluate` in the create-assessment advanced settings.
- `proctored-exam` and `formative-practice` presets now enable `autoEvaluate`.
- Warn when "immediate" feedback is selected with auto-evaluation off (nothing would show until manual evaluation).

**Tests**
- Rewrote the submit-trigger tests for per-student semantics: fires even when not all students have submitted; enqueues only the submitting student; records a single-item `auto_on_submit` job.

## Verification
- Full backend suite: **608 passed**.
- Instructor frontend: `type-check` clean, `lint` 0 errors.

## Notes
- The SQS consumer that processes evaluation jobs runs in the API process — auto-eval takes effect once the backend is running.
- Existing answers with no scores can be evaluated via the existing manual "Evaluate All" control (or the batch endpoint).